### PR TITLE
Typescript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "useDimensions - a React Hook to measure DOM nodes",
     "main": "lib/index.js",
     "module": "es/index.js",
+    "typings": "src/index",
     "files": [
         "es",
         "lib",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "typescript": "^3.5.2"
     },
     "devDependencies": {
+        "@types/react": "^16.8.20",
         "nwb": "0.21.x",
         "react": "^16.8.4",
         "react-dom": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "devDependencies": {
         "nwb": "0.21.x",
         "react": "^16.8.4",
-        "react-dom": "^16.8.4"
+        "react-dom": "^16.8.4",
+        "typescript": "^3.5.2"
     },
     "author": "Swizec Teller",
     "homepage": "https://swizec.com",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,3 @@
+import { UseDimensionsArgs, UseDimensionsHook } from "./types";
+declare function useDimensions({ liveMeasure }?: UseDimensionsArgs): UseDimensionsHook;
+export default useDimensions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ function useDimensions({
         }
     }, [node]);
 
-    return [ref, dimensions, node];
+    return [ref, dimensions as DimensionObject, node];
 }
 
 export default useDimensions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function useDimensions({
     liveMeasure = true
 }: UseDimensionsArgs = {}): UseDimensionsHook {
     const [dimensions, setDimensions] = useState({});
-    const [node, setNode] = useState(null);
+    const [node, setNode] = useState<HTMLElement | null>(null);
 
     const ref = useCallback(node => {
         setNode(node);
@@ -44,6 +44,7 @@ function useDimensions({
                 };
             }
         }
+        return () => {}
     }, [node]);
 
     return [ref, dimensions as DimensionObject, node];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,9 +10,9 @@ export interface DimensionObject {
 }
 
 export type UseDimensionsHook = [
-    (node: HTMLElement) => void,
-    {} | DimensionObject,
-    HTMLElement
+    (node: HTMLElement | null) => void,
+    DimensionObject,
+    HTMLElement | null
 ];
 
 export interface UseDimensionsArgs {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,15 +5,15 @@
         "target": "es2015",
         "lib": ["es5", "es6", "es7", "es2017", "dom"],
         "sourceMap": true,
-        "allowJs": false, // todo: make this false when all .js files have been converted to .ts/.tsx
+        "allowJs": false,
         "jsx": "react",
         "moduleResolution": "node",
         "rootDirs": ["src"],
         "forceConsistentCasingInFileNames": true,
-        //    "noImplicitReturns": true,    // todo: enable this when all .js files have been converted to .ts/.tsx
-        //    "noImplicitThis": true,       // todo: enable this when all .js files have been converted to .ts/.tsx
-        //    "noImplicitAny": true,        // todo: enable this when all .js files have been converted to .ts/.tsx
-        //    "strictNullChecks": true,     // todo: enable this when all .js files have been converted to .ts/.tsx
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
         "removeComments": true,
         "suppressImplicitAnyIndexErrors": true,
         "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
         "removeComments": true,
         "suppressImplicitAnyIndexErrors": true,
         "noUnusedLocals": true,
-        "declaration": false, // todo: make this true when all .js files have been converted to .ts/.tsx
+        "declaration": true,
         "allowSyntheticDefaultImports": true,
         "experimentalDecorators": true,
         "esModuleInterop": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,19 +7,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.44.tgz#b00cf3595c6a3d75740af9768739a8125053a5a9"
   integrity sha512-HY3SK7egERHGUfY8p6ztXIEQWcIPHouYhCGcLAPQin7gE2G/fALFz+epnMwcxKUS6aKqTVoAFdi+t1llQd3xcw==
 
-"@types/prop-types@*":
-  version "15.7.1"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
-  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
-
-"@types/react@^16.8.20":
-  version "16.8.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
-  integrity sha512-ZLmI+ubSJpfUIlQuULDDrdyuFQORBuGOvNnMue8HeA0GVrAJbWtZQhcBvnBPNRBI/GrfSfrKPFhthzC2SLEtLQ==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
 JSONStream@^1.0.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2551,11 +2538,6 @@ csso@~2.3.1:
   dependencies:
     clap "^1.0.9"
     source-map "^0.5.3"
-
-csstype@^2.2.0:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
-  integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -8716,6 +8698,11 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.5.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-es@^3.3.4:
   version "3.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.44.tgz#b00cf3595c6a3d75740af9768739a8125053a5a9"
   integrity sha512-HY3SK7egERHGUfY8p6ztXIEQWcIPHouYhCGcLAPQin7gE2G/fALFz+epnMwcxKUS6aKqTVoAFdi+t1llQd3xcw==
 
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
+"@types/react@^16.8.20":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
+  integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 JSONStream@^1.0.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2538,6 +2551,11 @@ csso@~2.3.1:
   dependencies:
     clap "^1.0.9"
     source-map "^0.5.3"
+
+csstype@^2.2.0:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Related with #16 

- Updated `tsconfig.json` to export type declarations.
- Added typings property in `package.json`.
- Updated `tsconfig.json` with more restricted rules, resolving todos.
- Minor changes in typings to adjust output interface to Hooks interface.
- Added Typescript as devDependency instead of assume that it is installed globally.
- Added @types/react as devDependency. Now it is required due _noImplicitAny_ rule.
