### PR TITLE
Swap `{top,left}` definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ function getDimensionObject(node: HTMLElement): DimensionObject {
     return {
         width: rect.width,
         height: rect.height,
-        top: "x" in rect ? rect.x : rect.top,
-        left: "y" in rect ? rect.y : rect.left,
+        left: "left" in rect ? rect.left : rect.x,
+        top: "top" in rect ? rect.top : rect.y,
         x: "x" in rect ? rect.x : rect.left,
         y: "y" in rect ? rect.y : rect.top,
         right: rect.right,


### PR DESCRIPTION
Fixes #12 
I am using this as a workaround for now:
```
  const [ref, { x: left, y: top}] = useDimensions()
```