### PR TITLE
feat: make scroll tracking optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ function getDimensionObject(node: HTMLElement): DimensionObject {
 }
 
 function useDimensions({
-    liveMeasure = true
+    liveMeasure = true,
+    trackScrolling = true
 }: UseDimensionsArgs = {}): UseDimensionsHook {
     const [dimensions, setDimensions] = useState({});
     const [node, setNode] = useState(null);
@@ -36,13 +37,19 @@ function useDimensions({
 
             if (liveMeasure) {
                 window.addEventListener("resize", measure);
-                window.addEventListener("scroll", measure);
-
-                return () => {
-                    window.removeEventListener("resize", measure);
-                    window.removeEventListener("scroll", measure);
-                };
             }
+            if (trackScrolling) {
+                window.addEventListener("scroll", measure);
+            }
+
+            return () => {
+                if (liveMeasure) {
+                    window.removeEventListener("resize", measure);
+                }
+                if (trackScrolling) {
+                    window.removeEventListener("scroll", measure);
+                }
+            };
         }
     }, [node]);
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -17,4 +17,5 @@ export type UseDimensionsHook = [
 
 export interface UseDimensionsArgs {
     liveMeasure?: boolean;
+    trackScrolling?: boolean;
 }


### PR DESCRIPTION
In some cases tracking of the scroll is unnecessary, so I think it's better to be optional and by default enabled.

By the name of the package it seems to be for calculation dimensions not tracking the position.